### PR TITLE
Update installation instructions to use requirements files for FastAPI and Flask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install flask flasgger
 or
 
 ```shell
-pip install fastapi uvicorn jinja2 python-multipart
+pip install -r requirements_fastapi.txt
 ```
 
 - Start the server:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ source http/bin/activate
 - Install the [Flask](https://github.com/pallets/flask) or [FastAPI](https://github.com/tiangolo/fastapi) framework to your choice:
 
 ```shell
-pip install flask flasgger
+pip install -r requirements_flask.txt
 ```
 
 or

--- a/requirements_fastapi.txt
+++ b/requirements_fastapi.txt
@@ -1,0 +1,16 @@
+annotated-types==0.7.0
+anyio==4.4.0
+click==8.1.7
+exceptiongroup==1.2.2
+fastapi==0.112.3
+h11==0.14.0
+idna==3.8
+Jinja2==3.1.4
+MarkupSafe==2.1.5
+pydantic==2.8.2
+pydantic_core==2.20.1
+python-multipart==0.0.9
+sniffio==1.3.1
+starlette==0.38.4
+typing_extensions==4.12.2
+uvicorn==0.30.6

--- a/requirements_flask.txt
+++ b/requirements_flask.txt
@@ -1,0 +1,17 @@
+attrs==24.2.0
+blinker==1.8.2
+click==8.1.7
+flasgger==0.9.7.1
+Flask==3.0.3
+itsdangerous==2.2.0
+Jinja2==3.1.4
+jsonschema==4.23.0
+jsonschema-specifications==2023.12.1
+MarkupSafe==2.1.5
+mistune==3.0.2
+packaging==24.1
+PyYAML==6.0.2
+referencing==0.35.1
+rpds-py==0.20.0
+six==1.16.0
+Werkzeug==3.0.4


### PR DESCRIPTION
This pull request updates the project’s installation instructions to use ```requirements_fastapi.txt``` and ```requirements_flask.txt``` for installing dependencies, rather than manually typing all package names.